### PR TITLE
Fix incorrect lock for active-sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/NicolasMarlier/active-sync
-  revision: af6ae3aa41a422ebcf73c99f74149c483c116ebe
+  revision: aaa325393eaee3ecbab21214509aa1b85695d19a
   branch: master
   specs:
     active-sync (0.1.0)


### PR DESCRIPTION
Got this error during `bundle install` : 

```
Fetching https://github.com/NicolasMarlier/active-sync
fatal: Could not parse object 'af6ae3aa41a422ebcf73c99f74149c483c116ebe'.
Git error: command `git reset --hard af6ae3aa41a422ebcf73c99f74149c483c116ebe`
in directory /usr/local/bundle/bundler/gems/active-sync-af6ae3aa41a4 has failed.
If this error persists you could try removing the cache directory
'/usr/local/bundle/cache/bundler/git/active-sync-f5a3d4bbec9bbf0338ca4bca6387f47039c52cad'
```

Gemfile.lock references a non-existing commit : `af6ae3aa41a422ebcf73c99f74149c483c116ebe`
The last commit on active-sync#master is `aaa325393eaee3ecbab21214509aa1b85695d19a`